### PR TITLE
[#22] Remove references to `org.eclipse.xtext.generator` bundle

### DIFF
--- a/kim/org.integratedmodelling.kim.target/org.integratedmodelling.kim.target.target
+++ b/kim/org.integratedmodelling.kim.target/org.integratedmodelling.kim.target.target
@@ -18,7 +18,6 @@
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
   <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-  <unit id="org.eclipse.xtext.generator.feature.group" version="0.0.0"/>
 <repository location="https://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.27.0/"/>
 </location>
 </locations>

--- a/kim/org.integratedmodelling.kim/META-INF/MANIFEST.MF
+++ b/kim/org.integratedmodelling.kim/META-INF/MANIFEST.MF
@@ -15,7 +15,6 @@ Require-Bundle: org.eclipse.xtext,
  org.eclipse.xtend.lib;bundle-version="2.14.0",
  org.eclipse.emf.common,
  com.ibm.icu,
- org.eclipse.xtext.generator,
  org.integratedmodelling.klab.api;bundle-version="0.11.0",
  org.integratedmodelling.kactors;bundle-version="0.11.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-11


### PR DESCRIPTION
* This is a deprecated bundle, not present in `org.eclipse.xtext.sdk` feature anymore.

* The Xtext team recommends (since version 2.27.0) to switch to the "new" generator

* Removing those references and testing via maven `mvn clean install -DskipTests` seems to work just fine