### PR TITLE
Remove dependencies from com.google.html.types

### DIFF
--- a/api/org.integratedmodelling.klab.api/src/org/integratedmodelling/klab/utils/Utils.java
+++ b/api/org.integratedmodelling.klab.api/src/org/integratedmodelling/klab/utils/Utils.java
@@ -8,10 +8,13 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import org.integratedmodelling.klab.Services;
 import org.integratedmodelling.klab.api.knowledge.IConcept;
@@ -713,4 +716,66 @@ public class Utils {
 		return value;
 	}
 
+	/*
+     * This code is inspired by the <code>sanitize</code> method from <code>com.google.common.html.types.SafeUrls</code>.
+     * The original library is not up to date and contains several vulnerabilities.
+     * @see <a href="https://www.javadoc.io/doc/com.google.common.html.types/types/1.0.4/com/google/common/html/types/SafeUrls.html#sanitize-java.lang.String-java.util.Set-">Original documentation</a>
+     * Comments are taken from the original code 
+     */
+    private static final Set<String> DEFAULT_SAFE_STARTS = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList("http", "https", "mailto", "ftp")));
+    private static final String SAFE_URL = "about:invalid";
+    
+    /**
+     * Sanitizes the given {@code url}, validating that the input string matches a pattern of commonly
+     * used safe URLs. If {@code url} fails validation, this method returns
+     * {@code about:invalid}
+     * 
+     * <p>Specifically, {@code url} may be a URL with any of the default safe schemes (http, https,
+     * ftp, mailto), or a relative URL (i.e., a URL without a scheme; specifically, a scheme-relative,
+     * absolute-path-relative, or path-relative URL).
+     * 
+     * @see http://url.spec.whatwg.org/#concept-relative-url
+     * 
+     * <p>A sanitized URL is a string that carries the security type contract that its value
+     * will not cause untrusted script execution when evaluated as a hyperlink URL in a browser.
+     *
+     * <p>Values of this type are guaranteed to be safe to use in URL/hyperlink contexts, such as
+     * assignment to URL-valued DOM properties, in the sense that the use will not result in a
+     * Cross-Site-Scripting vulnerability. Similarly, a safe url can be interpolated into the URL context
+     * of an HTML template (e.g., inside a href attribute). However, appropriate HTML-escaping must
+     * still be applied.
+     *
+     * <p>Note that this type's contract does not imply any guarantees regarding the resource the URL
+     * refers to. In particular, the sanitized URLs are <b>not</b> safe to use in a context where the referred-to
+     * resource is interpreted as trusted code, e.g., as the src of a script tag.
+     * 
+     */
+    public static String sanitizeUrl(String url) {
+        String lowerCased = url.toLowerCase();
+
+        // If some Unicode character lower cases to something that ends up matching these ASCII ones, it's harmless.
+        for (String protocol : DEFAULT_SAFE_STARTS) {
+          if (lowerCased.startsWith(protocol + ":")) {
+            return url;
+          }
+        }
+        
+        for (int i = 0; i < url.length(); i++) {
+          switch (url.charAt(i)) {
+            case '/':
+            case '?':
+            case '#':
+              // After this the string can end or contain anything else, it won't be interpreted
+              // as the scheme.
+              return url;
+            case ':':
+              // This character is not allowed before seeing one of the above characters.
+              return SAFE_URL;
+            default:
+              // Other characters ok.
+              continue;
+          }
+        }
+        return url;
+    }
 }

--- a/klab.node/pom.xml
+++ b/klab.node/pom.xml
@@ -102,13 +102,6 @@
 			<dependency> <groupId>org.eclipse.jetty</groupId> <artifactId>jetty-jsp</artifactId>
 			<version>9.3.0.M1</version> </dependency> -->
 
-		<!-- for SafeUrl to help sanitize imported resource names -->
-		<dependency>
-			<groupId>com.google.common.html.types</groupId>
-			<artifactId>types</artifactId>
-			<version>1.0.8</version>
-		</dependency>
-
 		<!-- unzip uploaded resources -->
 		<dependency>
 			<groupId>net.lingala.zip4j</groupId>

--- a/klab.node/src/main/java/org/integratedmodelling/klab/node/resources/ResourceCatalog.java
+++ b/klab.node/src/main/java/org/integratedmodelling/klab/node/resources/ResourceCatalog.java
@@ -45,9 +45,6 @@ import org.integratedmodelling.klab.utils.Path;
 import org.integratedmodelling.klab.utils.Utils;
 import org.integratedmodelling.klab.utils.ZipUtils;
 
-import com.google.common.html.types.SafeUrl;
-import com.google.common.html.types.SafeUrls;
-
 /**
  * The node resource catalog is very similar to the local resource catalog,
  * except it uses the datadir/resource path for all resources, removes project
@@ -100,8 +97,8 @@ public class ResourceCatalog implements IResourceCatalog {
 		id = id.replaceAll("\\s+", ".");
 		// all .N become _N
 		id = id.replaceAll("\\.([0-9])", "_$1");
-		SafeUrl url = SafeUrls.sanitize(id);
-		String ret = url.getSafeUrlString();
+		
+		String ret = Utils.sanitizeUrl(id);
 		return ret;
 	}
 

--- a/products/semantic/pom.xml
+++ b/products/semantic/pom.xml
@@ -66,12 +66,6 @@
     		<version>1.0.1</version>
     	</dependency>
  -->
-		<!-- for SafeUrl to help sanitize imported resource names -->
-		<dependency>
-			<groupId>com.google.common.html.types</groupId>
-			<artifactId>types</artifactId>
-			<version>1.0.8</version>
-		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->
 		<dependency>


### PR DESCRIPTION
The original library is not up to date and contains several vulnerabilities.