### PR TITLE
fix for proper style export in zip when downloading observations

### DIFF
--- a/klab.engine/src/main/java/org/integratedmodelling/klab/engine/rest/controllers/engine/EngineViewController.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/engine/rest/controllers/engine/EngineViewController.java
@@ -360,7 +360,13 @@ public class EngineViewController {
         if (!done && format == GeometryType.RAW) {
 
             // should have a format field
-            File out = File.createTempFile("klab", "." + outputFormat);
+            File out;
+            if(outputFormat.equals("tiff")){
+                // for visualization we export also with the style files, so we need to change to zip
+                out = File.createTempFile("klab", ".zip");
+            }else {
+                out = File.createTempFile("klab", "." + outputFormat);
+            }
             // TODO support explicit adapter
             out = Observations.INSTANCE.export(obs, loc, out, outputFormat, null, session.getMonitor());
             if (out != null) {	


### PR DESCRIPTION
This fixes the geotiff download, which from the view/data should also create the style file.

But I am still a bit puzzeled about why the response always chooses *.zip as extension. Wasn't able to find out where that is picked.