### PR TITLE
IM-110 Delete temporary files as part of remote session clean-up

### DIFF
--- a/klab.engine/src/main/java/org/integratedmodelling/klab/utils/FileUtils.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/utils/FileUtils.java
@@ -125,10 +125,24 @@ public class FileUtils extends org.apache.commons.io.FileUtils {
 		return ret;
 	}
 
+	/**
+	 * Deletes the temporary files used in observations. The file name must match the pattern:
+	 * `geo*.tiff`, `ktmp*.dat`, `wcs*.xml`. Files older than `lastModified` are deleted.
+	 * 
+	 * @param lastModified the date used as threshold
+	 */
+	public static void deleteTempFiles(long lastModified) {
+		String fileNamePattern = "(^geo.*tiff$|^ktmp.*dat$|^wcs.*xml$)";
+
+		listFiles(getTempDirectory(), null, false).stream().filter(f -> {
+			return isFileOlder(f, lastModified) && f.getName().matches(fileNamePattern);
+		}).forEach(f -> {
+			deleteQuietly(f);
+		});
+	}
+
 	public static void main(String[] args) {
-		for (String dio : tailFile(new File("C:\\setup.log"), 5)) {
-			System.out.println(dio);
-		}
+		deleteTempFiles(1678968628350L);
 	}
 
 	public static final List<String> tailFile(File file, final int noOfLines) {

--- a/products/cloud/src/main/java/org/integratedmodelling/klab/engine/RemoteEngine.java
+++ b/products/cloud/src/main/java/org/integratedmodelling/klab/engine/RemoteEngine.java
@@ -2,6 +2,8 @@ package org.integratedmodelling.klab.engine;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -19,6 +21,7 @@ import org.integratedmodelling.klab.engine.services.AgentServiceCheck;
 import org.integratedmodelling.klab.engine.services.ConsulDnsService;
 import org.integratedmodelling.klab.exceptions.KlabAuthorizationException;
 import org.integratedmodelling.klab.exceptions.KlabException;
+import org.integratedmodelling.klab.utils.FileUtils;
 
 public class RemoteEngine extends Engine {
 
@@ -73,8 +76,9 @@ public class RemoteEngine extends Engine {
     @Override
     protected void closeExpiredSessions() {
         if (!Authentication.INSTANCE.getSessions().isEmpty()) {
+            long current = System.currentTimeMillis();
+            long yesterday = Instant.now().minus(1, ChronoUnit.DAYS).toEpochMilli();
             try {
-                long current = System.currentTimeMillis();
                 activeSessions().forEach(sesh -> {
                     long last = sesh.getLastActivity() + (sessionDeadBand * 60000);
                     if (last < (current)) {
@@ -90,6 +94,7 @@ public class RemoteEngine extends Engine {
             } catch (Exception e) {
                 Logging.INSTANCE.info(e.toString());
             }
+            FileUtils.deleteTempFiles(yesterday);
         }
     }
 


### PR DESCRIPTION
* We have 8GB allocated for the `/tmp` folder in remote engine containers. We want to clean up temporary files of old observations.
* The `closeExpiredSessions` method is triggered every minute, no need to call the same code on session logout