### PR TITLE
[#55] Exclude javax.annotation artifact from copies jars

### DIFF
--- a/products/cli/pom.xml
+++ b/products/cli/pom.xml
@@ -23,6 +23,7 @@
 							<overWriteReleases>false</overWriteReleases>
 							<overWriteSnapshots>false</overWriteSnapshots>
 							<overWriteIfNewer>true</overWriteIfNewer>
+							<excludeArtifactIds>javax.annotation</excludeArtifactIds>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
We use maven-dependency-plugin/copy-dependencies to move all the jars to the `lib/` folder. There are 2 different jars that provide the same packages `javax.annotation.*`

The jars provided by Eclipse are signed, leading to the signer exception.

Closes #55 