### PR TITLE
[#72] Expose only public api to Swagger

### DIFF
--- a/api/org.integratedmodelling.klab.api/src/org/integratedmodelling/klab/api/PublicAPI.java
+++ b/api/org.integratedmodelling.klab.api/src/org/integratedmodelling/klab/api/PublicAPI.java
@@ -1,0 +1,26 @@
+/*
+ * This file is part of k.LAB.
+ * 
+ * k.LAB is free software: you can redistribute it and/or modify it under the terms of the Affero
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * A copy of the GNU Affero General Public License is distributed in the root directory of the k.LAB
+ * distribution (LICENSE.txt). If this cannot be found see <http://www.gnu.org/licenses/>.
+ * 
+ * Copyright (C) 2023 integratedmodelling.org and any authors mentioned in author tags. All
+ * rights reserved.
+ */
+package org.integratedmodelling.klab.api;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface PublicAPI {
+
+}

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/engine/rest/controllers/base/SwaggerConfig.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/engine/rest/controllers/base/SwaggerConfig.java
@@ -2,6 +2,7 @@ package org.integratedmodelling.klab.engine.rest.controllers.base;
 
 import java.util.Collections;
 
+import org.integratedmodelling.klab.api.PublicAPI;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -28,7 +29,7 @@ public class SwaggerConfig {
 
     @Bean
     public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2).select().apis(RequestHandlerSelectors.any()).paths(PathSelectors.any())
+        return new Docket(DocumentationType.SWAGGER_2).select().apis(RequestHandlerSelectors.withClassAnnotation(PublicAPI.class)).paths(PathSelectors.any())
                 .build().apiInfo(apiInfo());
     }
 

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/engine/rest/controllers/engine/EnginePublicController.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/engine/rest/controllers/engine/EnginePublicController.java
@@ -17,6 +17,7 @@ import org.integratedmodelling.klab.Klab;
 import org.integratedmodelling.klab.Observations;
 import org.integratedmodelling.klab.Resources;
 import org.integratedmodelling.klab.api.API;
+import org.integratedmodelling.klab.api.PublicAPI;
 import org.integratedmodelling.klab.api.auth.IUserIdentity;
 import org.integratedmodelling.klab.api.auth.Roles;
 import org.integratedmodelling.klab.api.data.ILocator;
@@ -66,6 +67,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @CrossOrigin(origins = "*")
 @Secured(Roles.SESSION)
+@PublicAPI
 public class EnginePublicController implements API.PUBLIC {
 
 	@RequestMapping(value = CREATE_CONTEXT, method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)


### PR DESCRIPTION
- Introduce a new `@PublicAPI` annotation, used for filtering the public controllers