### PR TITLE
Manage STAC Assets via id instead of band title

### DIFF
--- a/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACEncoder.java
+++ b/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACEncoder.java
@@ -159,8 +159,8 @@ public class STACEncoder implements IResourceEncoder {
 
 			// Allow transform ensures the process to finish, but I would not bet on the resulting data.
 			final boolean allowTransform = true;
-            String assetName = resource.getParameters().contains("asset") ? resource.getParameters().get("asset", String.class) : "undefined title";
-            HMRaster outRaster = HMStacCollection.readRasterBandOnRegion(regionTransformed, assetName, items, allowTransform, lpm);
+            String assetId = resource.getParameters().get("asset", String.class);
+            HMRaster outRaster = HMStacCollection.readRasterBandOnRegion(regionTransformed, assetId, items, allowTransform, lpm);
 
 			coverage = outRaster.buildCoverage();
 			scope.getMonitor().info("Coverage: " + coverage);

--- a/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACService.java
+++ b/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACService.java
@@ -71,7 +71,7 @@ public class STACService {
     public IGeometry getGeometry(IParameters<String> parameters) {
         String catalogUrl = parameters.get("catalogUrl", String.class);
         String collectionId = parameters.get("collectionId", String.class);
-        String item = parameters.get("band", String.class);
+        String item = parameters.get("asset", String.class);
         GeometryBuilder gBuilder = Geometry.builder();
 
         JsonNode collectionMetadata = STACUtils.requestCollectionMetadata(catalogUrl, collectionId);

--- a/adapters/klab.ogc/src/main/resources/ogc/prototypes/stac.kdl
+++ b/adapters/klab.ogc/src/main/resources/ogc/prototypes/stac.kdl
@@ -13,7 +13,7 @@
  	final text 'collectionId'
  		"The ID of the annotated data collection."
  		
- 	optional text 'band'
- 		"The title of a multi-feature query. Leave it empty for resources with a single feature."
+ 	final text 'asset'
+ 		"The id of the asset to be read"
  		
  }


### PR DESCRIPTION
Minor change to get closer to the STAC naming convention.
Related to a [PR](https://github.com/TheHortonMachine/hortonmachine/pull/89) for the HortonMachine project.