### PR TITLE
Im 257 recreation idb adapter automatic instantiation within the geographical scope of the context

### DIFF
--- a/components/klab.component.random/src/main/java/org/integratedmodelling/random/adapters/RecreationIDBAdapter.java
+++ b/components/klab.component.random/src/main/java/org/integratedmodelling/random/adapters/RecreationIDBAdapter.java
@@ -37,7 +37,6 @@ import org.integratedmodelling.klab.rest.ExternalAuthenticationCredentials;
 import org.integratedmodelling.klab.rest.ResourceReference;
 import org.integratedmodelling.klab.scale.Scale;
 
-import kong.unirest.GetRequest;
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
 import kong.unirest.Unirest;
@@ -169,7 +168,7 @@ public class RecreationIDBAdapter implements IUrnAdapter {
             return statesData.getJSONArray("features").toList().stream().map(
                     feature -> ((JSONObject) feature).getJSONObject("properties").getString("iso_1").replaceFirst("US-", "")).toList();
         } catch (JSONException e) {
-            throw new KlabResourceAccessException(e);
+            throw new KlabResourceAccessException("Error while parsing \"urban_heat_modelling:gadm_level_1_usa\"");
         }
     }
 

--- a/components/klab.component.random/src/main/java/org/integratedmodelling/random/adapters/RecreationIDBAdapter.java
+++ b/components/klab.component.random/src/main/java/org/integratedmodelling/random/adapters/RecreationIDBAdapter.java
@@ -175,14 +175,16 @@ public class RecreationIDBAdapter implements IUrnAdapter {
 
     private List<String> buildRecreationIDBInput(Map<String, String> parameters, IEnvelope envelope)
             throws UnsupportedEncodingException {
-        List<String> states = getStatesFromEnvelope(envelope);
+        // The list is initialized with the list of territories and DC, which cannot be queried by the same means as the states
+        List<String> regions = List.of("DC", "AS", "GU", "MP", "PR", "VI");
+        regions.addAll(getStatesFromEnvelope(envelope));
         List<String> query = new ArrayList<>();
 		for (Map.Entry<String, String> entry : parameters.entrySet()) {
 			String parameter = entry.getKey() + "=" + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8.toString());
 			query.add(parameter);
 		}
 		String finalQuery = String.join("&", query);
-		return states.stream().map(state -> finalQuery + "&" + STATE + "=" + state).toList();
+		return regions.stream().map(state -> finalQuery + "&" + STATE + "=" + state).toList();
 	}
 
 	private IGeometry makeScale(Urn urn, IShape shape, IContextualizationScope scope) {

--- a/components/klab.component.random/src/main/java/org/integratedmodelling/random/adapters/RecreationIDBAdapter.java
+++ b/components/klab.component.random/src/main/java/org/integratedmodelling/random/adapters/RecreationIDBAdapter.java
@@ -90,9 +90,6 @@ public class RecreationIDBAdapter implements IUrnAdapter {
 		if (urn.getParameters().containsKey(OFFSET)) {
 			parameters.put(OFFSET, urn.getParameters().get(OFFSET));
 		}
-		if (urn.getParameters().containsKey(STATE)) {
-			parameters.put(STATE, urn.getParameters().get(STATE));
-		}
 		if (urn.getParameters().containsKey(ACTIVITY)) {
 			parameters.put(ACTIVITY, urn.getParameters().get(ACTIVITY));
 		}
@@ -158,7 +155,6 @@ public class RecreationIDBAdapter implements IUrnAdapter {
         HttpResponse<JsonNode> response = Unirest.get("https://integratedmodelling.org/aux-geoserver/ows?service=WFS&version=2.0.0&request=GetFeature&typeNames=urban_heat_modelling:gadm_level_1_usa&bbox="
                 + envelope.getMinX() +"," + envelope.getMinY() + "," + envelope.getMaxX() + "," + envelope.getMaxY()
                 + ",EPSG:4326&outputFormat=application/json").asJson();
-
         if (!response.isSuccess()) {
             throw new KlabResourceNotFoundException("Cannot retrieve information from geoserver resource \"urban_heat_modelling:gadm_level_1_usa\".");
         }
@@ -172,20 +168,11 @@ public class RecreationIDBAdapter implements IUrnAdapter {
         }
     }
 
-	private final List<String> USA_STATES = Arrays.asList("AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL", "GA",
-			"HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA", "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE", "NV",
-			"NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK", "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT", "VA",
-			"WA", "WV", "WI", "WY");
     private List<String> buildRecreationIDBInput(Map<String, String> parameters, IEnvelope envelope)
             throws UnsupportedEncodingException {
         List<String> states = getStatesFromEnvelope(envelope);
         List<String> query = new ArrayList<>();
-        // TODO revise this zombie code before making a PR. It might be useful
-        // states = parameters.containsKey(STATE) ? Arrays.asList(parameters.get(STATE).split(",")) : USA_STATES;
 		for (Map.Entry<String, String> entry : parameters.entrySet()) {
-			if (entry.getKey().equals(STATE)) {
-				continue;
-			}
 			String parameter = entry.getKey() + "=" + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8.toString());
 			query.add(parameter);
 		}


### PR DESCRIPTION
These changes are applied to the RecreationIDB adapter, which requests data state by state.

Previously, the states had to be present as a parameter in the URN. The new version can identify the states within the spatial context by obtaining the bbox of the context and filtering the states from the geoserver layer `urban_heat_modelling:gadm_level_1_usa`.