### PR TITLE
Filter out recreation areas outside the context

### DIFF
--- a/components/klab.component.random/src/main/java/org/integratedmodelling/random/adapters/RecreationIDBAdapter.java
+++ b/components/klab.component.random/src/main/java/org/integratedmodelling/random/adapters/RecreationIDBAdapter.java
@@ -135,6 +135,11 @@ public class RecreationIDBAdapter implements IUrnAdapter {
 				// to the areas are points.
 				shape = Shape.create(lon, lat, (Projection) scope.getScale().getSpace().getProjection());
 
+                // Discard points that are not inside the polygon
+                if (!space.contains(shape)) {
+                    continue;
+                }
+
 				Builder obuilder = builder.startObject(scope.getTargetName(), siteName, makeScale(urn, shape, scope));
 
 				// Add attributes to each recreation area like the name and id.


### PR DESCRIPTION
A pretty simple change: we just don't add those recreation areas inside the context.

Side note: the indentation mixes tabs and spaces, I am aware of that. Before merging the changes at #129, we should refactor everything to our preferred formatting.