### PR TITLE
Im 339 avoid using the url as the key of credentials

### DIFF
--- a/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/openeo/OpenEO.java
+++ b/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/openeo/OpenEO.java
@@ -395,8 +395,8 @@ public class OpenEO {
 	}
 
 	public OpenEO(String endpoint) {
-		this.endpoint = endpoint;
 		ExternalAuthenticationCredentials credentials = Authentication.INSTANCE.getCredentials(endpoint);
+		this.endpoint = credentials.getURL();
 		if (credentials != null) {
 			this.authorization = new Authorization(credentials, endpoint);
 		}

--- a/api/org.integratedmodelling.klab.api/src/org/integratedmodelling/klab/rest/ExternalAuthenticationCredentials.java
+++ b/api/org.integratedmodelling.klab.api/src/org/integratedmodelling/klab/rest/ExternalAuthenticationCredentials.java
@@ -35,6 +35,11 @@ public class ExternalAuthenticationCredentials {
      */
     private String scheme = "basic";
 
+    /**
+     * The URL of the authentication service
+     */
+    private String url = "";
+
     public List<String> getCredentials() {
         return credentials;
     }
@@ -51,4 +56,11 @@ public class ExternalAuthenticationCredentials {
         this.scheme = scheme;
     }
 
+    public String getURL() {
+        return url;
+    }
+
+    public void setURL(String url) {
+        this.url = url;
+    }
 }

--- a/klab.authentication/src/main/java/org/integratedmodelling/klab/Authentication.java
+++ b/klab.authentication/src/main/java/org/integratedmodelling/klab/Authentication.java
@@ -50,6 +50,7 @@ import org.integratedmodelling.klab.rest.IdentityReference;
 import org.integratedmodelling.klab.rest.ObservableReference;
 import org.integratedmodelling.klab.utils.FileCatalog;
 import org.integratedmodelling.klab.utils.MiscUtilities;
+import org.integratedmodelling.klab.utils.URLUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
@@ -418,8 +419,35 @@ public enum Authentication implements IAuthenticationService {
         return ret;
     }
 
-    public ExternalAuthenticationCredentials getCredentials(String hostUrl) {
-        return externalCredentials.get(hostUrl);
+    /**
+     * Returns a credential for the selected host. It can be an ID or an URL as long as it is presented in the credentials.
+     * @param endpoint as a URL or an ID defined in the credentials
+     * @return
+     */
+    public ExternalAuthenticationCredentials getCredentials(String endpoint) {
+        if (URLUtils.isCompliant(endpoint)) {
+            return getCredentialsByUrl(endpoint);
+        }
+        return getCredentialsById(endpoint);
+    }
+
+    /**
+     * Returns a credential for the selected host URL. If multiple host URL are present, the first in alphabetical order will be returned.
+     * @param hostUrl
+     * @return the credential or null if not present
+     */
+    private ExternalAuthenticationCredentials getCredentialsByUrl(String hostUrl) {
+        return externalCredentials.values().stream().filter(credential -> credential.getURL().equals(hostUrl))
+                .sorted().findFirst().orElse(null);
+    }
+
+    /**
+     * Returns a credential for the selected ID.
+     * @param id
+     * @return the credential or null if not present
+     */
+    private ExternalAuthenticationCredentials getCredentialsById(String id) {
+        return externalCredentials.get(id);
     }
 
     /**

--- a/klab.authentication/src/main/java/org/integratedmodelling/klab/Authentication.java
+++ b/klab.authentication/src/main/java/org/integratedmodelling/klab/Authentication.java
@@ -50,7 +50,6 @@ import org.integratedmodelling.klab.rest.IdentityReference;
 import org.integratedmodelling.klab.rest.ObservableReference;
 import org.integratedmodelling.klab.utils.FileCatalog;
 import org.integratedmodelling.klab.utils.MiscUtilities;
-import org.integratedmodelling.klab.utils.URLUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
@@ -425,7 +424,7 @@ public enum Authentication implements IAuthenticationService {
      * @return
      */
     public ExternalAuthenticationCredentials getCredentials(String endpoint) {
-        if (URLUtils.isCompliant(endpoint)) {
+        if (endpoint.startsWith("http://") || endpoint.startsWith("https://")) {
             return getCredentialsByUrl(endpoint);
         }
         return getCredentialsById(endpoint);

--- a/klab.authentication/src/main/java/org/integratedmodelling/klab/Authentication.java
+++ b/klab.authentication/src/main/java/org/integratedmodelling/klab/Authentication.java
@@ -537,8 +537,9 @@ public enum Authentication implements IAuthenticationService {
      * - Move the URL as its own parameter
      * - Changes on the scheme of oidc credentials
      */
-    private void updateLegacyCredentials() {
-        boolean isLegacyDetected = externalCredentials.values().stream().anyMatch(cr -> cr.getURL() == null || cr.getURL().isEmpty());
+    public void updateLegacyCredentials() {
+        boolean isLegacyDetected = externalCredentials.values().stream()
+                .anyMatch(credential -> credential.getURL() == null || credential.getURL().isEmpty());
         if (!isLegacyDetected) {
             return;
         }
@@ -568,10 +569,10 @@ public enum Authentication implements IAuthenticationService {
         });
         // We remove the old credentials by their IDs
         legacyCredentialIds.forEach(id -> externalCredentials.remove(id));
+        externalCredentials.write();
     }
 
     public void addExternalCredentials(String id, ExternalAuthenticationCredentials credentials) {
-        updateLegacyCredentials();
         externalCredentials.put(id, credentials);
         externalCredentials.write();
     }

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/auth/Authorization.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/auth/Authorization.java
@@ -34,7 +34,6 @@ public class Authorization {
     private long expiry = -1;
     private String prefix;
     private String tokenType;
-    private String endpoint;
 
     /**
      * Create a new authorization. {@link #isOnline()} should be called after creation.
@@ -67,7 +66,6 @@ public class Authorization {
             if (endpoint == null) {
                 throw new KlabIllegalArgumentException("Attempted to start an OIDC authoritation workflow without an endpoint");
             }
-            this.endpoint = endpoint;
             refreshToken();
         }
     }
@@ -82,13 +80,13 @@ public class Authorization {
     }
 
     private Pair<String, String> parseProvider() {
-        HttpResponse<JsonNode> response = Unirest.get(endpoint + "/credentials/oidc").asJson();
+        HttpResponse<JsonNode> response = Unirest.get(credentials.getURL() + "/credentials/oidc").asJson();
         if (!response.isSuccess()) {
-            throw new KlabAuthorizationException("Cannot access " + endpoint + " for OIDC authentication");
+            throw new KlabAuthorizationException("Cannot access " + credentials.getURL() + " for OIDC authentication");
         }
         List<JSONObject> providers = response.getBody().getObject().getJSONArray("providers").toList();
         JSONObject provider = providers.stream().filter(prov -> prov.getString("id").equals(credentials.getCredentials().get(3))).findFirst()
-                .orElseThrow(() -> new KlabAuthorizationException("No known provider '" + credentials.getCredentials().get(3) + "' at " + endpoint));
+                .orElseThrow(() -> new KlabAuthorizationException("No known provider '" + credentials.getCredentials().get(3) + "' at " + credentials.getURL()));
         List<String> scopes = provider.getJSONArray("scopes").toList();
         String scope = scopes.stream().collect(Collectors.joining(" "));
         return new Pair<>(provider.getString("issuer"), scope);

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/cli/commands/credentials/Set.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/cli/commands/credentials/Set.java
@@ -21,7 +21,6 @@ public class Set implements ICommand {
 
     @Override
     public Object execute(IServiceCall call, ISession session) {
-
         String ret = "";
         List<?> args = (List<?>) call.getParameters().get("arguments");
         String id = (String) call.getParameters().get("id");
@@ -45,7 +44,7 @@ public class Set implements ICommand {
             try {
                 id = new URL(url).getHost();
             } catch (MalformedURLException e) {
-                e.printStackTrace();
+               throw new KlabValidationException("Cannot generate credential ID from URL " + url);
             }
         }
 

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/cli/commands/credentials/Set.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/cli/commands/credentials/Set.java
@@ -22,7 +22,16 @@ public class Set implements ICommand {
     @Override
     public Object execute(IServiceCall call, ISession session) {
         String ret = "";
+        if (call.getParameters().containsKey("update")) {
+            Authentication.INSTANCE.updateLegacyCredentials();
+            ret += "Credentials updated.";
+        }
+
         List<?> args = (List<?>) call.getParameters().get("arguments");
+        if (args.isEmpty()) {
+            return ret;
+        }
+
         String id = (String) call.getParameters().get("id");
         String url = (String) call.getParameters().get("url");
         String scheme = (String) call.getParameters().get("scheme");

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/cli/commands/credentials/Set.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/cli/commands/credentials/Set.java
@@ -2,7 +2,6 @@ package org.integratedmodelling.klab.cli.commands.credentials;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.integratedmodelling.kim.api.IServiceCall;

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/cli/commands/credentials/Set.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/cli/commands/credentials/Set.java
@@ -1,5 +1,8 @@
 package org.integratedmodelling.klab.cli.commands.credentials;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.integratedmodelling.kim.api.IServiceCall;
@@ -22,23 +25,36 @@ public class Set implements ICommand {
 
         String ret = "";
         List<?> args = (List<?>) call.getParameters().get("arguments");
-        String scheme = "basic";
-        int nargs = 3;
+        String id = (String) call.getParameters().get("id");
+        String url = (String) call.getParameters().get("url");
+        String scheme = (String) call.getParameters().get("scheme");
         int astart = 0;
-        if (args.size() > 0) {
-            if (ExternalAuthenticationCredentials.parameterKeys.containsKey(args.get(0).toString())) {
-                scheme = args.get(0).toString();
-                astart = 1;
+
+        if (scheme == null) {
+            scheme = args.get(astart).toString();
+            astart++;
+        }
+        List<String> params = List.of(ExternalAuthenticationCredentials.parameterKeys.get(scheme));
+        int nargs = params.size() + astart;
+
+        if (url == null) {
+            url = args.get(astart).toString();
+            astart++;
+            nargs++;
+        }
+        if (id == null) {
+            try {
+                id = new URL(url).getHost();
+            } catch (MalformedURLException e) {
+                e.printStackTrace();
             }
         }
 
-        String[] params = ExternalAuthenticationCredentials.parameterKeys.get(scheme);
-        if (params == null) {
+        if (params.isEmpty()) {
             throw new KlabIllegalArgumentException("unrecognized authorization scheme");
         }
 
-        nargs = params.length + 1; // the URL
-        if (args.size() != (nargs + astart)) {
+        if (args.size() != nargs) {
             throw new KlabValidationException("expecting " + nargs + " arguments for scheme " + scheme);
         }
 
@@ -47,13 +63,13 @@ public class Set implements ICommand {
         ExternalAuthenticationCredentials credentials = new ExternalAuthenticationCredentials();
 
         credentials.setScheme(scheme);
-        for (int i = astart + 1; i < (astart + nargs); i++) {
+        credentials.setURL(url);
+        for (int i = astart; i < nargs; i++) {
             credentials.getCredentials().add(args.get(i).toString());
-            ret += "\n   " + params[i - astart - 1] + ": " + args.get(i).toString();
+            ret += "\n   " + params.get(i - astart) + ": " + args.get(i).toString();
+        };
 
-        }
-
-        Authentication.INSTANCE.addExternalCredentials(args.get(astart).toString(), credentials);
+        Authentication.INSTANCE.addExternalCredentials(id, credentials);
 
         return ret;
 

--- a/klab.engine/src/main/resources/cli/commands/credentials.kdl
+++ b/klab.engine/src/main/resources/cli/commands/credentials.kdl
@@ -3,17 +3,17 @@
 @namespace credentials
 
 void set
-	"Call with <authentication method> <hostname[:port]> <parameters> to add credentials for an external host.\n
+	"Call with <scheme> <hostname[:port]> <parameters> to add credentials for an external host.\n
 	     The parameters depend on the authentication method and should be one of the following:\n
-	      - basic: <hostname[:port]> <username> <password>\n
-	      - oidc: <hostname[:port]> <grant_type> <client_id> <client_secrets> <provider_id>\n
-	      - key: <hostname[:port]> <key>"
+	      - basic: <username> <password>\n
+	      - oidc: <grant_type> <client_id> <client_secrets> <provider_id>\n
+	      - key: <key>"
 {
 	optional text scheme
 		"Authentication method. It has to be one of the following: basic, oidc, key."
 
 	optional text url
-		"URL of the service used to obtain the credentials. If not defined, will be taken from the first argument."
+		"URL of the service used to obtain the credentials."
 
 	optional text id
 		"Identifier of the credentials. If not provided, it will be extracted from the URL."

--- a/klab.engine/src/main/resources/cli/commands/credentials.kdl
+++ b/klab.engine/src/main/resources/cli/commands/credentials.kdl
@@ -9,5 +9,14 @@ void set
 	      - oidc: <hostname[:port]> <grant_type> <client_id> <client_secrets> <provider_id>\n
 	      - key: <hostname[:port]> <key>"
 {
+	optional text scheme
+		"Authentication method. It has to be one of the following: basic, oidc, key."
+
+	optional text url
+		"URL of the service used to obtain the credentials. If not defined, will be taken from the first argument."
+
+	optional text id
+		"Identifier of the credentials. If not provided, it will be extracted from the URL."
+
 	class org.integratedmodelling.klab.cli.commands.credentials.Set
 }

--- a/klab.engine/src/main/resources/cli/commands/credentials.kdl
+++ b/klab.engine/src/main/resources/cli/commands/credentials.kdl
@@ -18,5 +18,8 @@ void set
 	optional text id
 		"Identifier of the credentials. If not provided, it will be extracted from the URL."
 
+	optional void update
+		"Updates the existing credential schemes if required"
+
 	class org.integratedmodelling.klab.cli.commands.credentials.Set
 }


### PR DESCRIPTION
Upgraded the credential schema:
- Extra flexibility on defining the command
- Use an alternative ID for each credential
- Read credentials via ID or URL
- Semi-automatic update of credentials