### PR TITLE
Im 416 filter out osm features outside the context

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,7 @@ pipeline {
         stage('Maven install with jib') {
             steps {
                 withCredentials([usernamePassword(credentialsId: "${env.REGISTRY_CREDENTIALS}", passwordVariable: 'PASSWORD', usernameVariable: 'USERNAME')]) {
-                    sh './mvnw -U clean install -DskipTests jib:build -Djib.httpTimeout=60000'
+                    sh './mvnw -U clean install -DskipTests jib:build -Djib.httpTimeout=180000'
                     sh './mvnw -pl :klab.ogc -pl :klab.node test -Dtest="*STAC*,Authentication*"'
                 }
             }

--- a/Jenkinsfile.withParams
+++ b/Jenkinsfile.withParams
@@ -159,7 +159,7 @@ pipeline {
         stage('Maven install with jib') {
             steps {
                 withCredentials([usernamePassword(credentialsId: "${params.REGISTRY_CREDENTIALS}", passwordVariable: 'PASSWORD', usernameVariable: 'USERNAME')]) {
-                    sh './mvnw clean install -U -DskipTests jib:build -Djib.httpTimeout=60000'
+                    sh './mvnw clean install -U -DskipTests jib:build -Djib.httpTimeout=180000'
                 }
             }
         }

--- a/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACEncoder.java
+++ b/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACEncoder.java
@@ -208,7 +208,7 @@ public class STACEncoder implements IResourceEncoder {
             // data.
             final boolean allowTransform = true;
             String assetId = resource.getParameters().get("asset", String.class);
-            HMRaster outRaster = HMStacCollection.readRasterBandOnRegion(regionTransformed, assetId, items, allowTransform, mergeMode, lpm);
+            HMRaster outRaster = collection.readRasterBandOnRegion(regionTransformed, assetId, items, allowTransform, mergeMode, lpm);
             coverage = outRaster.buildCoverage();
         } catch (Exception e) {
             throw new KlabInternalErrorException("Cannot build STAC raster output. Reason " + e.getMessage());

--- a/adapters/klab.ogc/src/test/java/org/integratedmodelling/klab/ogc/test/StacTest.java
+++ b/adapters/klab.ogc/src/test/java/org/integratedmodelling/klab/ogc/test/StacTest.java
@@ -114,7 +114,7 @@ public class StacTest {
 
         int cols = 979, rows = 676;
         RegionMap regionMap = RegionMap.fromEnvelopeAndGrid(env, cols, rows);
-        HMRaster raster = HMStacCollection.readRasterBandOnRegion(regionMap, stacBand, items, true, HMRaster.MergeMode.AVG, lpm);
+        HMRaster raster = collection.readRasterBandOnRegion(regionMap, stacBand, items, true, HMRaster.MergeMode.AVG, lpm);
         lpm.message("Raster: " + raster + "\n-------\n");
 
         manager.close();

--- a/components/klab.component.hydrology/src/main/java/org/integratedmodelling/geoprocessing/remotesensing/SentinelResolver.java
+++ b/components/klab.component.hydrology/src/main/java/org/integratedmodelling/geoprocessing/remotesensing/SentinelResolver.java
@@ -116,7 +116,7 @@ public class SentinelResolver extends AbstractContextualizer implements IResolve
                         DefaultGeographicCRS.WGS84).transform(outputCrs, true);
                 RegionMap regionTransformed = RegionMap.fromEnvelopeAndGrid(regionEnvelopeTransformed, (int) cols, (int) rows);
 
-                HMRaster outRaster = HMStacCollection.readRasterBandOnRegion(regionTransformed, stacBand, items, true, HMRaster.MergeMode.AVG, taskMonitor);
+                HMRaster outRaster = collection.readRasterBandOnRegion(regionTransformed, stacBand, items, true, HMRaster.MergeMode.AVG, taskMonitor);
                 
                 
                 GridCoverage2D outCoverage = outRaster.buildCoverage();

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/components/geospace/processing/osm/OSMQuery.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/components/geospace/processing/osm/OSMQuery.java
@@ -80,6 +80,10 @@ public class OSMQuery {
 		this.maxresults = maxresults;
 	}
 
+    public void setSpatialBoundaries(SpatialBoundaries spatialBoundaries) {
+        this.spatialBoundaries = spatialBoundaries;
+    }
+
 	public void filterEqual(Object... strings) {
 		for (int i = 0; i < strings.length; i++) {
 			Object key = strings[i];
@@ -280,9 +284,4 @@ public class OSMQuery {
 		}
 		return ret;
 	}
-
-    public void setSpatialBoundaries(SpatialBoundaries spatialBoundaries) {
-        this.spatialBoundaries = spatialBoundaries;
-    }
-
 }

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/components/geospace/processing/osm/OSMQuery.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/components/geospace/processing/osm/OSMQuery.java
@@ -5,11 +5,13 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.integratedmodelling.klab.api.observations.scale.space.IEnvelope;
 import org.integratedmodelling.klab.api.observations.scale.space.IShape;
 import org.integratedmodelling.klab.components.geospace.extents.Projection;
+import org.integratedmodelling.klab.components.geospace.extents.Shape;
 import org.integratedmodelling.klab.utils.Pair;
 
 /*
@@ -148,7 +150,7 @@ public class OSMQuery {
 		}
 
 		for (String what : getTypes()) {
-			String q = what + getFilters() + getBoundingBox() + ";";
+			String q = what + getFilters() + "(poly:" + getGeometry() + ");";
 			if (what.equals("way") || what.equals("rel")) {
 				// the result set plus all the composing ways and nodes
 				q += "\n(._; >;);";
@@ -218,6 +220,16 @@ public class OSMQuery {
 		}
 		return q ? ("\"" + first + "\"") : first;
 	}
+
+    private String getGeometry() {
+        List<List<Double>> coordinates = (List) ((List) ((Shape) shape).asGeoJSON().get("coordinates")).get(0);
+        String overpassPolygon = "\"";
+        for (List<Double> coord : (List<List<Double>>)coordinates) {
+            overpassPolygon += coord.get(1) + " " + coord.get(0) + " ";
+        }
+        overpassPolygon = overpassPolygon.substring(0, overpassPolygon.length() - 1) + "\"";
+        return overpassPolygon;
+    }
 
 	private String getBoundingBox() {
 

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/components/geospace/processing/osm/OSMSubjectInstantiator.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/components/geospace/processing/osm/OSMSubjectInstantiator.java
@@ -267,7 +267,7 @@ public class OSMSubjectInstantiator extends AbstractContextualizer implements II
 				break;
 
 			} catch (Throwable e) {
-				context.getMonitor().debug("Overpass server at " + ourl + " failed to respond");
+				context.getMonitor().debug("Overpass server at " + url + " failed to respond");
 				exception = e;
 			}
 		}

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/components/geospace/processing/osm/OSMSubjectInstantiator.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/components/geospace/processing/osm/OSMSubjectInstantiator.java
@@ -1,13 +1,14 @@
 package org.integratedmodelling.klab.components.geospace.processing.osm;
 
+import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -34,6 +35,7 @@ import org.integratedmodelling.klab.components.runtime.contextualizers.AbstractC
 import org.integratedmodelling.klab.data.Metadata;
 import org.integratedmodelling.klab.exceptions.KlabException;
 import org.integratedmodelling.klab.exceptions.KlabIOException;
+import org.integratedmodelling.klab.exceptions.KlabRemoteException;
 import org.integratedmodelling.klab.exceptions.KlabValidationException;
 import org.integratedmodelling.klab.scale.Scale;
 import org.integratedmodelling.klab.utils.CamelCase;
@@ -63,6 +65,11 @@ import de.topobyte.osm4j.geometry.RegionBuilderResult;
 import de.topobyte.osm4j.geometry.WayBuilder;
 import de.topobyte.osm4j.geometry.WayBuilderResult;
 import de.topobyte.osm4j.xml.dynsax.OsmXmlIterator;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
 
 /**
  * Subject instantiator to extract features from OSM. Either pass an Overpass
@@ -183,13 +190,22 @@ public class OSMSubjectInstantiator extends AbstractContextualizer implements II
 
 		Throwable exception = null;
 
-		for (String ourl : Geocoder.OVERPASS_URLS) {
-
-			String url = ourl + "?data=" + Escape.forURL(query);
+		for (String url : Geocoder.OVERPASS_URLS) {
 
 			context.getMonitor().debug("Opening Overpass query " + url);
 
-			try (InputStream input = new URL(url).openStream()) {
+            OkHttpClient client = new OkHttpClient().newBuilder().callTimeout(360, TimeUnit.SECONDS).build();
+            MediaType mediaType = MediaType.parse("text/plain");
+            RequestBody body = RequestBody.create(mediaType, query);
+
+            Request request = new Request.Builder().url(url).method("POST", body).build();
+            Response response = null;
+            try {
+                response = client.newCall(request).execute();
+            } catch (IOException ex) {
+                throw new KlabRemoteException(ex);
+            }
+			try (InputStream input = response.body().byteStream()) {
 
 				OsmIterator iterator = new OsmXmlIterator(input, true);
 				InMemoryMapDataSet data = MapDataSetLoader.read(iterator, true, true, true);

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/components/geospace/processing/osm/OSMSubjectInstantiator.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/components/geospace/processing/osm/OSMSubjectInstantiator.java
@@ -39,7 +39,6 @@ import org.integratedmodelling.klab.exceptions.KlabRemoteException;
 import org.integratedmodelling.klab.exceptions.KlabValidationException;
 import org.integratedmodelling.klab.scale.Scale;
 import org.integratedmodelling.klab.utils.CamelCase;
-import org.integratedmodelling.klab.utils.Escape;
 import org.integratedmodelling.klab.utils.Parameters;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
@@ -95,7 +94,6 @@ public class OSMSubjectInstantiator extends AbstractContextualizer implements II
 	boolean isTemporal = false;
 	boolean fixGeometries = false;
 
-	// String outputType = null;
 	String query = null;
 
 	boolean canDispose = false;
@@ -168,12 +166,6 @@ public class OSMSubjectInstantiator extends AbstractContextualizer implements II
 		    this.spatialBoundaries = SpatialBoundaries.valueOf(parameters.get("spatial-boundaries", String.class));
 		}
 	}
-
-//    @Override
-//    public IGeometry getGeometry() {
-//        // TODO Auto-generated method stub
-//        return null;
-//    }
 
 	@Override
 	public Type getType() {

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/components/geospace/processing/osm/OSMSubjectInstantiator.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/components/geospace/processing/osm/OSMSubjectInstantiator.java
@@ -115,7 +115,18 @@ public class OSMSubjectInstantiator extends AbstractContextualizer implements II
 	private int timeout = 600;
 	private boolean simplifyShapes = false;
 	double bufferDistance = Double.NaN;
+    SpatialBoundaries spatialBoundaries;
 
+    public enum SpatialBoundaries {
+        bbox("bbox"),
+        poly("poly"),
+        ;
+
+        public String type;
+        SpatialBoundaries(String type) {
+            this.type = type;
+        }
+    }
 
 	public OSMSubjectInstantiator() {
 	}
@@ -152,6 +163,9 @@ public class OSMSubjectInstantiator extends AbstractContextualizer implements II
 		}
 		if (parameters.containsKey("simplify-polygons")) {
 			this.simplifyShapes = parameters.get("simplify-polygons", Boolean.class);
+		}
+		if (parameters.containsKey("spatial-boundaries")) {
+		    this.spatialBoundaries = SpatialBoundaries.valueOf(parameters.get("spatial-boundaries", String.class));
 		}
 	}
 
@@ -323,6 +337,7 @@ public class OSMSubjectInstantiator extends AbstractContextualizer implements II
 		if (this.notmatching != null) {
 			query.filterNotMatch(this.notmatching.toArray());
 		}
+        query.setSpatialBoundaries(spatialBoundaries);
 
 		return query.toString();
 	}

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/components/geospace/processing/osm/OSMSubjectInstantiator.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/components/geospace/processing/osm/OSMSubjectInstantiator.java
@@ -208,7 +208,7 @@ public class OSMSubjectInstantiator extends AbstractContextualizer implements II
 
 			context.getMonitor().debug("Opening Overpass query " + url);
 
-            OkHttpClient client = new OkHttpClient().newBuilder().callTimeout(360, TimeUnit.SECONDS).build();
+            OkHttpClient client = new OkHttpClient().newBuilder().callTimeout(timeout, TimeUnit.SECONDS).build();
             MediaType mediaType = MediaType.parse("text/plain");
             RequestBody body = RequestBody.create(mediaType, query);
 

--- a/klab.engine/src/main/resources/components/org.integratedmodelling.geospace/services/osm.kdl
+++ b/klab.engine/src/main/resources/components/org.integratedmodelling.geospace/services/osm.kdl
@@ -58,6 +58,12 @@ const export object query
 		"If true, set the temporal extent for the retrieved features from the OSM metadata. If the
          metadata do not help, set to the temporal extent in the context."
          default false
-		
+
+    optional enum spatial-boundaries
+        "Sets the spatial boundaries of the query. The potential values are bbox and poly, the first
+         being the default value. For extremely complex polygons, poly might return a timeout."
+           values bbox, poly
+           default bbox
+
 	class org.integratedmodelling.klab.components.geospace.processing.osm.OSMSubjectInstantiator
 }

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
 		<!-- Careful here: geotools must be right for hortonmachine to work; JTS
 			should be the same one that geotools and HM needs. -->
 		<geotools.version>28.0</geotools.version>
-		<hortonmachine.version>0.10.8-SNAPSHOT</hortonmachine.version>
+		<hortonmachine.version>0.10.9-SNAPSHOT</hortonmachine.version>
 		<jts.version>1.18.1</jts.version>
 		<h2gis.version>1.5.0</h2gis.version>
 		<maven.compiler.source>11</maven.compiler.source>


### PR DESCRIPTION
Changelog:
- Make the overpass queries use the polygon of the context instead of the bbox.
- Bump the HortonMachine version and increase the JIB timeout.