### PR TITLE
Avoid calling a null emergent observation

### DIFF
--- a/klab.engine/src/main/java/org/integratedmodelling/klab/components/network/model/Network.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/components/network/model/Network.java
@@ -148,7 +148,9 @@ public class Network extends Pattern implements INetwork {
 		case "gexf":
 			GEXFExporter<IDirectObservation, IRelationship> gexf = new GEXFExporter<>();
 			gexf.setCreator("k.LAB " + Version.CURRENT);
-			gexf.setDescription(emergentObservation.getMetadata().get(IMetadata.DC_COMMENT, "GEXF network export"));
+			if (emergentObservation != null) {
+				gexf.setDescription(emergentObservation.getMetadata().get(IMetadata.DC_COMMENT, "GEXF network export"));
+			}
 			gexf.setVertexAttributeProvider(vertexAttributeProvider);
 			gexf.setEdgeAttributeProvider(edgeAttributeProvider);
 			gexf.exportGraph(network, writer);


### PR DESCRIPTION
Fixed a small bug: the `emergentObservation` variable could be null and cause a classic `NullPointerException`, impeding the export of GEXF files.