### PR TITLE
Im 431 provide information about the nodes at network export and export CSV

### DIFF
--- a/klab.engine/src/main/java/org/integratedmodelling/klab/components/network/model/Network.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/components/network/model/Network.java
@@ -229,6 +229,7 @@ public class Network extends Pattern implements INetwork {
 		ret.add(new Triple<>("gexf", "GEXF 1.2 network (dynamic)", "gexf"));
 		ret.add(new Triple<>("graphml", "GraphML 1.0 graph (static)", "gml"));
 		ret.add(new Triple<>("json", "JSON (dynamic)", "json"));
+		ret.add(new Triple<>("csv", "CSV (static)", "csv"));
 		return ret;
 	}
 

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/components/network/model/Network.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/components/network/model/Network.java
@@ -119,6 +119,8 @@ public class Network extends Pattern implements INetwork {
 			double[] xy = v.getSpace().getShape().getCenter(true);
 			map.put("latitude", DefaultAttribute.createAttribute(xy[1]));
 			map.put("longitude", DefaultAttribute.createAttribute(xy[0]));
+			map.put("name", DefaultAttribute.createAttribute(v.getName()));
+			map.put("metadata", DefaultAttribute.createAttribute(v.getMetadata().toString()));
 			return map;
 		};
 

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/components/network/services/ConfigurableRelationshipInstantiator.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/components/network/services/ConfigurableRelationshipInstantiator.java
@@ -34,6 +34,7 @@ import org.integratedmodelling.klab.components.geospace.extents.Projection;
 import org.integratedmodelling.klab.components.geospace.extents.Shape;
 import org.integratedmodelling.klab.components.geospace.indexing.DistanceCalculator;
 import org.integratedmodelling.klab.components.runtime.contextualizers.AbstractContextualizer;
+import org.integratedmodelling.klab.data.Metadata;
 import org.integratedmodelling.klab.exceptions.KlabException;
 import org.integratedmodelling.klab.exceptions.KlabValidationException;
 import org.integratedmodelling.klab.scale.Scale;
@@ -342,7 +343,10 @@ public class ConfigurableRelationshipInstantiator extends AbstractContextualizer
             IDirectObservation source = (IDirectObservation) graph.getEdgeSource(edge);
             IDirectObservation target = (IDirectObservation) graph.getEdgeTarget(edge);
             IScale scale = getScale(source, target, edge instanceof SpatialEdge ? ((SpatialEdge) edge).targetShape : null);
-            ret.add(scope.newRelationship(observable, observable.getName() + "_" + i, scale, source, target, null));
+            // TODO find a better way of setting the metadata value
+            Metadata metadata = new Metadata();
+            metadata.put("cost", 1.0);
+            ret.add(scope.newRelationship(observable, observable.getName() + "_" + i, scale, source, target, metadata));
             i++;
         }
         return ret;


### PR DESCRIPTION
Changelog:
- Allowed download of connections as CSV.
- Added mock metadata to `network.connect`.
- Export metadata from the nodes.

This branch is still WIP, but some features are needed in the develop branch.