### PR TITLE
Im 436 log the progress of the valhalla network

### DIFF
--- a/klab.engine/src/main/java/org/integratedmodelling/klab/components/network/services/RoutingRelationshipInstantiator.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/components/network/services/RoutingRelationshipInstantiator.java
@@ -237,6 +237,8 @@ public class RoutingRelationshipInstantiator extends AbstractContextualizer impl
         Set<IObservation> connected = new HashSet<>();
         int nullTrajectories = 0;
         int outOfLimitTrajectories = 0;
+        int currentDecile = 1;
+        int potentialTrajectories = sources.size() * targets.size();
         for(IObservation source : sources) {
             if (connected.contains(source)) {
                 continue;
@@ -247,6 +249,11 @@ public class RoutingRelationshipInstantiator extends AbstractContextualizer impl
                     return;
                 }
 
+                int currentTrajectory = trajectories.size() + nullTrajectories + outOfLimitTrajectories;
+                if ((potentialTrajectories / 10) * currentDecile == currentTrajectory ) {
+                    context.getMonitor().debug("Network building progress at " + currentDecile + "0%");
+                    currentDecile++;
+                }
                 // A direct connection of an instance to itself in the context of routing makes
                 // no sense and is thus avoided.
                 // Note that closed paths are nevertheless possible.

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/components/network/services/RoutingRelationshipInstantiator.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/components/network/services/RoutingRelationshipInstantiator.java
@@ -53,6 +53,7 @@ public class RoutingRelationshipInstantiator extends AbstractContextualizer impl
 
 	private Double timeThreshold = null;
 	private Double distanceThreshold = null;
+	private int loggingThreshold = 10_000;
 
 	static enum TransportType {
 		Auto("auto"), Pedestrian("pedestrian"), Bicycle("bicycle"), Bus("bus"), Truck("truck"), Taxi("taxi"),
@@ -130,7 +131,10 @@ public class RoutingRelationshipInstantiator extends AbstractContextualizer impl
 		this.targetArtifact = parameters.get("target", String.class);
 		this.timeThreshold = parameters.get("time_limit", Double.class);
 		this.distanceThreshold = parameters.get("distance_limit", Double.class);
-
+		
+		if (parameters.containsKey("log_threshold")) {
+			this.loggingThreshold = parameters.get("log_threshold", Integer.class);
+		}
 		if (parameters.containsKey("transport")) {
 			this.transportType = TransportType.fromValue(Utils.removePrefix(parameters.get("transport", String.class)));
 		}
@@ -232,13 +236,15 @@ public class RoutingRelationshipInstantiator extends AbstractContextualizer impl
                 + Concepts.INSTANCE.getDisplayName(semantics.getType()) + " routing relationships.");
 		return instantiateRelationships(semantics);
 	}
-
+	
     private void connectSourceToTarget(IContextualizationScope context, List<IObservation> sources, List<IObservation> targets) {
         Set<IObservation> connected = new HashSet<>();
         int nullTrajectories = 0;
         int outOfLimitTrajectories = 0;
         int currentDecile = 1;
         int potentialTrajectories = sources.size() * targets.size();
+        boolean hasToLog = potentialTrajectories > loggingThreshold;
+        context.getMonitor().debug("Potential trajectories in the network: " + potentialTrajectories);
         for(IObservation source : sources) {
             if (connected.contains(source)) {
                 continue;
@@ -250,7 +256,7 @@ public class RoutingRelationshipInstantiator extends AbstractContextualizer impl
                 }
 
                 int currentTrajectory = trajectories.size() + nullTrajectories + outOfLimitTrajectories;
-                if ((potentialTrajectories / 10) * currentDecile == currentTrajectory ) {
+                if (hasToLog && ((potentialTrajectories / 10) * currentDecile == currentTrajectory)) {
                     context.getMonitor().debug("Network building progress at " + currentDecile + "0%");
                     currentDecile++;
                 }

--- a/klab.engine/src/main/resources/components/org.integratedmodelling.network/services/network.kdl
+++ b/klab.engine/src/main/resources/components/org.integratedmodelling.network/services/network.kdl
@@ -92,6 +92,9 @@ export object route
 
 	optional text server
 		"Specify the endpoint for the Valhalla server."
+
+	optional number log_threshold
+		"If the potential routes of a network surpasses the logging threshold, it will log the progress as a debug log. Default 10.000 potential routes."
 	
 //	TODO configuration to use 
 


### PR DESCRIPTION
Waiting for large networks to be finished took a long time and made more than a few modellers nervous as they got no feedback while waiting. This small change attempts to solve that:

Changelog:
- Log the progress of the Valhalla network after reaching a new decile of the potential routes. 
- Set the logging threshold as a parameter.