### PR TITLE
Im 521 allow more media types in stac

### DIFF
--- a/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACAssetParser.java
+++ b/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACAssetParser.java
@@ -9,7 +9,9 @@ import kong.unirest.json.JSONObject;
 
 public class STACAssetParser {
     // https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#common-media-types-in-stac
-    final private static Set<String> SUPPORTED_MEDIA_TYPE = Set.of("image/tiff;application=geotiff;profile=cloud-optimized","image/vnd.stac.geotiff;profile=cloud-optimized");
+    final private static Set<String> SUPPORTED_MEDIA_TYPE = Set.of("image/tiff;application=geotiff", "image/vnd.stac.geotiff",
+            "image/tiff;application=geotiff;profile=cloud-optimized", "image/vnd.stac.geotiff;profile=cloud-optimized",
+            "image/vnd.stac.geotiff;cloud-optimized=true", "application/geo+json");
 
     /** 
      * Check if the MIME value is supported.

--- a/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACCollectionParser.java
+++ b/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACCollectionParser.java
@@ -85,7 +85,9 @@ public class STACCollectionParser {
         // item_assets is a shortcut for obtaining information about the assets
         // https://github.com/stac-extensions/item-assets
         if (collection.has("item_assets")) {
-            return STACCollectionParser.readItemAssets(collection);
+            if (!collection.getJSONObject("item_assets").isEmpty()) {
+                return STACCollectionParser.readItemAssets(collection);
+            }
         }
 
         // TODO Move the query to another place. 


### PR DESCRIPTION
The valid data types were obtained from the following link: https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#common-media-types-in-stac
At this time, the permitted types are as follows:
- GeoTIFF
- Cloud Optimized GeoTIFF
- GeoJSON