### PR TITLE
Im 542 get s3 region by analyzing the asset href

### DIFF
--- a/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACCollectionParser.java
+++ b/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACCollectionParser.java
@@ -25,10 +25,6 @@ public class STACCollectionParser {
         return collection.getString("id");
     }
 
-    private static JSONObject readItemAssets(JSONObject collection) {
-        return collection.getJSONObject("item_assets");
-    }
-
     /**
      * Obtains the geometry from the collection data.
      * Currently, only available for dynamic collections.
@@ -80,14 +76,6 @@ public class STACCollectionParser {
                 throw new KlabResourceNotFoundException("Static STAC collection \"" + collectionUrl + "\" has no assets");
             }
             return collection.getJSONObject("assets");
-        }
-
-        // item_assets is a shortcut for obtaining information about the assets
-        // https://github.com/stac-extensions/item-assets
-        if (collection.has("item_assets")) {
-            if (!collection.getJSONObject("item_assets").isEmpty()) {
-                return STACCollectionParser.readItemAssets(collection);
-            }
         }
 
         // TODO Move the query to another place. 

--- a/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACEncoder.java
+++ b/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACEncoder.java
@@ -56,7 +56,6 @@ import org.locationtech.jts.geom.Polygon;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 
-import kong.unirest.apache.ApacheClient;
 import kong.unirest.json.JSONObject;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
@@ -274,8 +273,8 @@ public class STACEncoder implements IResourceEncoder {
                 scope.getMonitor().warn("Multiple EPSGs found on the items " + EPSGsAtItems.toString() + ". The transformation process could affect the data.");
             }
 
-            if (resource.getParameters().contains("s3BucketRegion")) {
-                String bucketRegion = resource.getParameters().get("s3BucketRegion", String.class);
+            if (resource.getParameters().contains("awsRegion")) {
+                String bucketRegion = resource.getParameters().get("awsRegion", String.class);
                 S3Client s3Client = buildS3Client(bucketRegion);
                 collection.setS3Client(s3Client);
             }

--- a/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACImporter.java
+++ b/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACImporter.java
@@ -24,8 +24,11 @@ import org.integratedmodelling.klab.api.runtime.monitoring.IMonitor;
 import org.integratedmodelling.klab.exceptions.KlabIOException;
 import org.integratedmodelling.klab.utils.Parameters;
 import org.integratedmodelling.klab.utils.Triple;
+import org.integratedmodelling.klab.utils.s3.S3RegionResolver;
+import org.integratedmodelling.klab.utils.s3.S3URLUtils;
 
 import kong.unirest.json.JSONObject;
+import software.amazon.awssdk.regions.Region;
 
 public class STACImporter implements IResourceImporter {
 
@@ -82,6 +85,12 @@ public class STACImporter implements IResourceImporter {
             }
             parameters.put("asset", assetId);
             String resourceUrn = collectionId + "-" + assetId;
+            String href = assetData.getString("href");
+            if (S3URLUtils.isS3Endpoint(href)) {
+                String[] bucketAndObject = href.split("://")[1].split("/", 2);
+                Region s3Region = S3RegionResolver.resolveBucketRegion(bucketAndObject[0], bucketAndObject[1]);
+                parameters.put("awsRegion", s3Region.id());
+            }
 
             Builder builder = buildResource(parameters, project, monitor, resourceUrn);
             if (builder != null) {

--- a/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACImporter.java
+++ b/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/stac/STACImporter.java
@@ -88,7 +88,7 @@ public class STACImporter implements IResourceImporter {
             String href = assetData.getString("href");
             if (S3URLUtils.isS3Endpoint(href)) {
                 String[] bucketAndObject = href.split("://")[1].split("/", 2);
-                Region s3Region = S3RegionResolver.resolveBucketRegion(bucketAndObject[0], bucketAndObject[1]);
+                Region s3Region = S3RegionResolver.resolveBucketRegion(bucketAndObject[0], bucketAndObject[1], monitor);
                 parameters.put("awsRegion", s3Region.id());
             }
 

--- a/adapters/klab.ogc/src/main/resources/ogc/prototypes/stac.kdl
+++ b/adapters/klab.ogc/src/main/resources/ogc/prototypes/stac.kdl
@@ -13,7 +13,4 @@
  	optional text 'asset'
  		"The asset that is going to be retrieved from the items."
  
- 	optional text 's3BucketRegion'
- 		"The Region for S3 elements."
- 
  }

--- a/klab.engine/pom.xml
+++ b/klab.engine/pom.xml
@@ -960,6 +960,18 @@
 				<version>${junit5.version}</version>
 				<scope>test</scope>
 			</dependency>
+		<!--- AWS dependencies-->
+		<dependency>
+			<artifactId>apache-client</artifactId> 
+			<groupId>software.amazon.awssdk</groupId> 
+			<version>${aws.version}</version> 
+ 			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 
 	</dependencies>
 </project>

--- a/klab.engine/pom.xml
+++ b/klab.engine/pom.xml
@@ -960,6 +960,12 @@
 				<version>${junit5.version}</version>
 				<scope>test</scope>
 			</dependency>
+			<dependency>
+				<groupId>org.mockito</groupId>
+				<artifactId>mockito-core</artifactId>
+				<version>${mockito.version}</version>
+				<scope>test</scope>
+			</dependency>
 		<!--- AWS dependencies-->
 		<dependency>
 			<artifactId>apache-client</artifactId> 

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/utils/s3/S3RegionResolver.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/utils/s3/S3RegionResolver.java
@@ -1,0 +1,107 @@
+package org.integratedmodelling.klab.utils.s3;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetBucketLocationRequest;
+import software.amazon.awssdk.services.s3.model.GetBucketLocationResponse;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+public class S3RegionResolver {
+
+    public static Region resolveBucketRegion(String bucketName, String objectKey) {
+        // Default region to start with for GetBucketLocation
+        Region defaultRegion = Region.US_EAST_1;
+
+        // Step 1: Attempt to dynamically resolve the bucket's region
+        try (S3Client s3 = S3Client.builder()
+                .region(defaultRegion) // Use the default region
+                .credentialsProvider(AnonymousCredentialsProvider.create()) // Anonymous credentials
+                .build()) {
+
+            System.out.println("Attempting to resolve region dynamically for bucket: " + bucketName);
+
+            GetBucketLocationRequest request = GetBucketLocationRequest.builder()
+                    .bucket(bucketName)
+                    .build();
+
+            GetBucketLocationResponse response = s3.getBucketLocation(request);
+            String location = response.locationConstraintAsString();
+
+            // Handle "null" or "global" regions
+            if (location == null || location.equalsIgnoreCase("null")) {
+                System.out.println("Bucket region resolved dynamically to: us-east-1");
+                return Region.US_EAST_1;
+            }
+
+            Region resolvedRegion = Region.of(location);
+            System.out.println("Bucket region resolved dynamically to: " + resolvedRegion);
+            return resolvedRegion;
+
+        } catch (Exception e) {
+            System.err.println("Failed to resolve region dynamically for bucket: " + bucketName + ". Error: " + e.getMessage());
+        }
+
+
+        // List of regions to exclude (e.g., isolated regions or restricted access regions)
+        List<Region> excludedRegions = List.of(
+                Region.US_ISO_EAST_1, // Restricted to isolated networks
+                Region.US_ISO_WEST_1, // Example of another restricted region
+                Region.CN_NORTH_1,    // China regions may require special accounts
+                Region.CN_NORTHWEST_1
+        );
+
+        // Get the list of all AWS regions, excluding problematic ones
+        List<Region> regions = Region.regions().stream()
+                .filter(region -> !excludedRegions.contains(region))
+                .collect(Collectors.toList());
+
+        System.out.println("Falling back to region testing for bucket: " + bucketName);
+
+
+        // Step 2: Iterate through all regions and test lightweight requests
+        return resolveRegionByTesting(bucketName, objectKey);
+    }
+
+    private static Region resolveRegionByTesting(String bucketName, String objectKey) {
+        // Get the list of all AWS regions
+        List<Region> regions = Region.regions();
+
+        System.out.println("Falling back to region testing for bucket: " + bucketName);
+
+        // Iterate through regions to perform a lightweight test
+        for (Region region : regions) {
+            try (S3Client s3 = S3Client.builder()
+                    .region(region)
+                    .credentialsProvider(AnonymousCredentialsProvider.create())
+                    .build()) {
+
+                System.out.println("Testing region: " + region);
+
+                // Perform a lightweight HEAD request to check if the object exists
+                HeadObjectRequest request = HeadObjectRequest.builder()
+                        .bucket(bucketName)
+                        .key(objectKey)
+                        .build();
+
+                s3.headObject(request); // If no exception is thrown, the region is correct
+                System.out.println("Region confirmed by testing: " + region);
+                return region;
+
+            } catch (S3Exception e) {
+                // Continue testing other regions if the bucket is not found
+                if (e.statusCode() != 403 && e.statusCode() != 404) {
+                    System.err.println("Error testing region " + region + ": " + e.awsErrorDetails().errorMessage());
+                }
+            } catch (Exception e) {
+                System.err.println("Exception testing region " + region + ": " + e.getMessage());
+            }
+        }
+
+        throw new RuntimeException("Unable to resolve region for bucket: " + bucketName);
+    }
+}

--- a/klab.engine/src/main/java/org/integratedmodelling/klab/utils/s3/S3RegionResolver.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/utils/s3/S3RegionResolver.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetBucketLocationRequest;
@@ -19,6 +20,7 @@ public class S3RegionResolver {
 
         // Step 1: Attempt to dynamically resolve the bucket's region
         try (S3Client s3 = S3Client.builder()
+                .httpClientBuilder(ApacheHttpClient.builder())
                 .region(defaultRegion) // Use the default region
                 .credentialsProvider(AnonymousCredentialsProvider.create()) // Anonymous credentials
                 .build()) {

--- a/klab.engine/src/test/java/org/integratedmodelling/klab/test/utils/S3RegionResolverTest.java
+++ b/klab.engine/src/test/java/org/integratedmodelling/klab/test/utils/S3RegionResolverTest.java
@@ -1,20 +1,22 @@
 package org.integratedmodelling.klab.test.utils;
 
+import org.integratedmodelling.klab.api.runtime.monitoring.IMonitor;
 import org.integratedmodelling.klab.exceptions.KlabResourceAccessException;
 import org.integratedmodelling.klab.utils.s3.S3RegionResolver;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import software.amazon.awssdk.regions.Region;
 
 public class S3RegionResolverTest {
-
     @Test
     public void resolveBucketRegion_resolutionSuccessful() {
         String bucket = "deafrica-input-datasets";
         String objectKey = "rainfall_chirps_monthly/chirps-v2.0_2024.03.tif";
+        IMonitor monitor = Mockito.mock(IMonitor.class);
 
-        Region ret = S3RegionResolver.resolveBucketRegion(bucket, objectKey);
+        Region ret = S3RegionResolver.resolveBucketRegion(bucket, objectKey, monitor);
 
         Assertions.assertEquals(Region.AF_SOUTH_1, ret);
     }
@@ -24,9 +26,10 @@ public class S3RegionResolverTest {
     public void resolveBucketRegion_resolutionUnsuccessful() {
         String bucket = "fake-bucket";
         String objectKey = "fake-object.tif";
+        IMonitor monitor = Mockito.mock(IMonitor.class);
 
         Assertions.assertThrows(KlabResourceAccessException.class, () -> {
-            S3RegionResolver.resolveBucketRegion(bucket, objectKey);
+            S3RegionResolver.resolveBucketRegion(bucket, objectKey, monitor);
         });
     }
 

--- a/klab.engine/src/test/java/org/integratedmodelling/klab/test/utils/S3RegionResolverTest.java
+++ b/klab.engine/src/test/java/org/integratedmodelling/klab/test/utils/S3RegionResolverTest.java
@@ -1,0 +1,31 @@
+package org.integratedmodelling.klab.test.utils;
+
+import org.integratedmodelling.klab.utils.s3.S3RegionResolver;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.regions.Region;
+
+public class S3RegionResolverTest {
+
+    @Test
+    public void resolveBucketRegion_resolutionSuccessful() {
+        String bucket = "deafrica-input-datasets";
+        String objectKey = "rainfall_chirps_monthly/chirps-v2.0_2024.03.tif";
+
+        Region ret = S3RegionResolver.resolveBucketRegion(bucket, objectKey);
+
+        Assertions.assertEquals(Region.AF_SOUTH_1, ret);
+    }
+
+    @Test
+    public void resolveBucketRegion_resolutionUnsuccessful() {
+        String bucket = "fake-bucket";
+        String objectKey = "fake-object.tif";
+
+        Assertions.assertThrows(RuntimeException.class, () -> {
+            S3RegionResolver.resolveBucketRegion(bucket, objectKey);
+        });
+    }
+
+}

--- a/klab.engine/src/test/java/org/integratedmodelling/klab/test/utils/S3RegionResolverTest.java
+++ b/klab.engine/src/test/java/org/integratedmodelling/klab/test/utils/S3RegionResolverTest.java
@@ -1,5 +1,6 @@
 package org.integratedmodelling.klab.test.utils;
 
+import org.integratedmodelling.klab.exceptions.KlabResourceAccessException;
 import org.integratedmodelling.klab.utils.s3.S3RegionResolver;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -19,11 +20,12 @@ public class S3RegionResolverTest {
     }
 
     @Test
+    // Warning: a relatively costly test (sometimes over 30 seconds)
     public void resolveBucketRegion_resolutionUnsuccessful() {
         String bucket = "fake-bucket";
         String objectKey = "fake-object.tif";
 
-        Assertions.assertThrows(RuntimeException.class, () -> {
+        Assertions.assertThrows(KlabResourceAccessException.class, () -> {
             S3RegionResolver.resolveBucketRegion(bucket, objectKey);
         });
     }


### PR DESCRIPTION
Changelog:
- The AWS region of the bucket is now obtained by analyzing the URL of the asset.
- Removed `item_assets` compatibility, as it lacked the `href` field needed for getting the bucket.
- Changed the name of `s3BucketRegion` to `awsRegion` and removed it as a parameter at the importer.