### PR TITLE
Validate the alpha value of the pixel before drawing

### DIFF
--- a/klab.engine/src/main/java/org/integratedmodelling/klab/components/geospace/processing/Rasterizer.java
+++ b/klab.engine/src/main/java/org/integratedmodelling/klab/components/geospace/processing/Rasterizer.java
@@ -239,9 +239,23 @@ public class Rasterizer<T> {
             for (int y = 0; y < this.raster.getHeight(); y++) {
                 xy[0] = x;
                 xy[1] = y;
-                setter.accept(decodeFloat(Float.intBitsToFloat(raster.getRGB(x, y))), xy);
+                if (!isPixelTransparent(x, y))
+                    setter.accept(decodeFloat(Float.intBitsToFloat(raster.getRGB(x, y))), xy);
             }
         }
+    }
+
+    /**
+     * Validates the alpha value of the pixel. If the alpha value is zero, the pixel is considered transparent.
+     * @param x coordinates
+     * @param y coordinates
+     * @return 
+     */
+    private boolean isPixelTransparent(int x, int y) {
+        int pixel = raster.getRGB(x, y);
+        int alpha = (pixel >> 24) & 0xff;
+
+        return alpha == 0;
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
Fixes the issue of rasterization drawing empty values as zeroes.