### PR TITLE
Solve bug in aries-team-issue #92

### DIFF
--- a/klab.engine/pom.xml
+++ b/klab.engine/pom.xml
@@ -144,16 +144,19 @@
 		</dependency>
 
 		<!-- POI for Excel -->
+		<!-- https://mvnrepository.com/artifact/org.apache.poi/poi -->
 		<dependency>
-			<groupId>org.apache.poi</groupId>
-			<artifactId>poi</artifactId>
-			<version>4.1.1</version>
+		    <groupId>org.apache.poi</groupId>
+		    <artifactId>poi</artifactId>
+		    <version>5.4.1</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/org.apache.poi/poi-ooxml -->
 		<dependency>
-			<groupId>org.apache.poi</groupId>
-			<artifactId>poi-ooxml</artifactId>
-			<version>5.4.0</version>
+		    <groupId>org.apache.poi</groupId>
+		    <artifactId>poi-ooxml</artifactId>
+		    <version>5.4.1</version>
 		</dependency>
+		
 
 		<!-- tiny Jar to pluralize subject names for folder IDs -->
 		<dependency>


### PR DESCRIPTION
Updating the `org.apache.poi` dependency to the latest version solved the issue with table creation.
It also resolved the issue with the `table` button in the apps.