### PR TITLE
Use iterable for WCS parsing

### DIFF
--- a/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/raster/wcs/WCSService.java
+++ b/adapters/klab.ogc/src/main/java/org/integratedmodelling/klab/raster/wcs/WCSService.java
@@ -643,7 +643,7 @@ public class WCSService {
                     // JXPathContext context = JXPathContext.newContext(capabilitiesType);
                     // System.out.println(MapUtils.dump(capabilitiesType) + "");
                     for (Object o : MapUtils.get(capabilitiesType, "wcs:Capabilities/wcs:Contents/wcs:CoverageSummary",
-                            Collection.class)) {
+                            List.class)) {
                         Map<String, Object> item = (Map<String, Object>) o;
                         Object name = item.get(version.getMajor() >= 2 ? COVERAGE_ID : IDENTIFIER);
                         if (name != null) {
@@ -652,7 +652,7 @@ public class WCSService {
                     }
 
                     for (Object o : MapUtils.get(capabilitiesType, "wcs:Capabilities/wcs:Contents/wcs:CoverageSummary",
-                            Collection.class)) {
+                            List.class)) {
 
                         Map<String, Object> item = (Map<String, Object>) o;
 


### PR DESCRIPTION
This fixes a bug while trying to import WCS resources from IDEAM. The object used to store some of the data obtained from the WCS parsing wasn't supported in k.LAB.

Reference: https://github.com/integratedmodelling/aries-team-issues/issues/94.