### PR TITLE
AI gen code to allow negative buffers

### DIFF
--- a/components/klab.component.hydrology/src/main/java/org/integratedmodelling/geoprocessing/core/FeatureBufferingInstantiator.java
+++ b/components/klab.component.hydrology/src/main/java/org/integratedmodelling/geoprocessing/core/FeatureBufferingInstantiator.java
@@ -25,83 +25,110 @@ import org.integratedmodelling.klab.utils.Parameters;
 
 public class FeatureBufferingInstantiator extends AbstractContextualizer implements IInstantiator, IExpression {
 
-	private double distance;
-	private String artifact;
-	private boolean subtract;
-	private double simplify = 0;
+    private double distance;
+    private String artifact;
+    private boolean subtract;
+    private double simplify = 0;
 
-	@Override
-	public Type getType() {
-		return Type.OBJECT;
-	}
+    @Override
+    public Type getType() {
+        return Type.OBJECT;
+    }
 
-	@Override
-	public Object eval(IContextualizationScope context, Object...params) throws KlabException {
-	    Parameters<String> parameters = Parameters.create(params);
-	    FeatureBufferingInstantiator ret = new FeatureBufferingInstantiator();
-		ret.distance = parameters.get("radius", Double.class);
-		ret.artifact = parameters.get("artifact", String.class);
-		ret.subtract = parameters.get("subtract", Boolean.FALSE);
-		ret.simplify = parameters.get("simplify", 0);
-		return ret;
-	}
+    @Override
+    public Object eval(IContextualizationScope context, Object... params) throws KlabException {
+        Parameters<String> parameters = Parameters.create(params);
+        FeatureBufferingInstantiator ret = new FeatureBufferingInstantiator();
+        ret.distance = parameters.get("radius", Double.class);
+        ret.artifact = parameters.get("artifact", String.class);
+        ret.subtract = parameters.get("subtract", Boolean.FALSE);
+        ret.simplify = parameters.get("simplify", 0);
+        return ret;
+    }
 
-	@Override
-	public List<IObjectArtifact> instantiate(IObservable semantics, IContextualizationScope context) throws KlabException {
+    @Override
+    public List<IObjectArtifact> instantiate(IObservable semantics, IContextualizationScope context)
+            throws KlabException {
 
-		IArtifact source = null;
-		boolean transform = false;
-		if (artifact == null) {
-			// transform target's extents
-			source = context.getTargetArtifact();
-			transform = true;
-		} else {
-			source = context.getArtifact(artifact);
-		}
+        IArtifact source = artifact == null ? context.getTargetArtifact() : context.getArtifact(artifact);
+        boolean transform = artifact == null;
 
-		if (!(source instanceof IObjectArtifact)) {
-			throw new IllegalArgumentException(
-					"buffer instantiator: source artifact does not exist or is not an object artifact");
-		}
+        if (!(source instanceof IObjectArtifact)) {
+            throw new IllegalArgumentException(
+                    "buffer instantiator: source artifact does not exist or is not an object artifact");
+        }
 
-		double bdistance = context.getScale().getSpace().getEnvelope().metersToDistance(this.distance);
+        double bdistance = context.getScale().getSpace().getEnvelope().metersToDistance(this.distance);
 
-		List<IObjectArtifact> ret = new ArrayList<>();
-		context.getMonitor().info("starting spatial buffer operation");
+        List<IObjectArtifact> ret = new ArrayList<>();
+        context.getMonitor().info("starting spatial buffer operation");
 
-		int tot = 0;
-		int spc = 0;
-		for (IArtifact obj : source) {
-			ISpace space = ((IObservation) obj).getSpace();
-			if (space != null) {
-				IShape oshape = space.getShape();
-				if (simplify > 0) {
-					oshape = ((Shape)oshape).getSimplified(simplify);
-				}
-				IShape newShape = oshape.buffer(bdistance);
-				if (simplify > 0) {
-					((Shape)newShape).simplify(simplify);
-				}
-				if (subtract && oshape.getGeometryType() != IShape.Type.POINT
-						&& oshape.getGeometryType() != IShape.Type.MULTIPOINT) {
-					newShape = newShape.difference(oshape);
-				}
-				IScale newScale = Scale.substituteExtent(((IObservation) obj).getScale(), newShape);
-				if (transform) {
-					((ObservedArtifact) obj).setGeometry(newScale);
-				} else {
-					ret.add(context.newObservation(semantics, ((IDirectObservation) obj).getName() + "_buffered",
-							newScale, /* TODO send useful metadata */null));
-				}
-				spc++;
-			}
-			tot++;
-		}
+        int tot = 0;
+        int spc = 0;
 
-		context.getMonitor().info("buffer operation " + (transform ? "modified" : "created") + " " + spc + " objects"
-				+ (tot > spc ? (" (" + (tot - spc) + " skipped)") : ""));
+        for (IArtifact obj : source) {
+            ISpace space = ((IObservation) obj).getSpace();
+            if (space == null) {
+                tot++;
+                continue;
+            }
 
-		return ret;
-	}
+            IShape originalShape = space.getShape();
+            IShape workingShape = originalShape;
 
+            // Optional simplification before buffering
+            if (simplify > 0) {
+                workingShape = ((Shape) workingShape).getSimplified(simplify);
+            }
+
+            // Apply buffer (positive = external, negative = internal)
+            IShape newShape = workingShape.buffer(bdistance);
+
+            // If buffer collapses, skip
+            if (newShape == null || newShape.isEmpty()) {
+                tot++;
+                continue;
+            }
+
+            // Optional simplification after buffering
+            if (simplify > 0) {
+                ((Shape) newShape).simplify(simplify);
+            }
+
+            // Subtract only makes sense for external buffers
+            if (subtract && distance > 0 &&
+                originalShape.getGeometryType() != IShape.Type.POINT &&
+                originalShape.getGeometryType() != IShape.Type.MULTIPOINT) {
+
+                newShape = newShape.difference(originalShape);
+
+                if (newShape == null || newShape.isEmpty()) {
+                    tot++;
+                    continue;
+                }
+            }
+
+            IScale newScale = Scale.substituteExtent(((IObservation) obj).getScale(), newShape);
+
+            if (transform) {
+                ((ObservedArtifact) obj).setGeometry(newScale);
+            } else {
+                ret.add(context.newObservation(
+                        semantics,
+                        ((IDirectObservation) obj).getName() + "_buffered",
+                        newScale,
+                        null
+                ));
+            }
+
+            spc++;
+            tot++;
+        }
+
+        context.getMonitor().info("buffer operation " + (transform ? "modified" : "created") + " " + spc
+                + (tot > spc ? (" (" + (tot - spc) + " skipped)") : ""));
+
+        return ret;
+    }
 }
+// REWRITTEN WITH COPILOT TO ALLOW NEGATIVE BUFFER


### PR DESCRIPTION
This code, which works for the feature requested by Ken, needs to be double checked as it is fully AI generated.

When given a negative radius now creates a new smaller object compared to the original one, considering the radius absolute value.
 
This allows to create a raster buffer in a second step:

e.g. try in "Bilbao"
```
model each ecology:Forest earth:Region
	observing landcover:LandCoverType named lct
	using gis.features.extract(select = [lct is landcover:Forest]); 

thing Banana;

private model each Banana
	observing ecology:Forest earth:Region named frg
	using 
		im.geoprocessing.buffer(artifact = frg, radius = -50, subtract = false);
		
thing Buffer;
		
model presence of Buffer
	 observing 
	 presence of Banana named bana,
     presence of ecology:Forest earth:Region named regio
     set to [regio == true && bana == false]
     ;
```
<img width="1148" height="682" alt="image" src="https://github.com/user-attachments/assets/b5a4a516-c165-4bd0-bb69-72f934108afe" />
